### PR TITLE
Add workflow to lint GitHub Action files with actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,17 @@
+name: Lint Action Files
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint action.yml files with actionlint
+        uses: rhysd/actionlint@v1.7.7


### PR DESCRIPTION
Hello and thanks for setup-dune!

I am interested in using this work, and I thought that I would help making the onboarding of external contribs easier to validate, if you like that.

This PR adds a GHA workflow that uses actionlint to lint all GitHub Actions workflow files on push and pull requests. This helps catch errors in workflow files early.

Notes:
- This hard-codes the OS since linting only needs to be done once and should be independent of OS.
- I left testing the functionality of the setup-dune action itself out of scope (I'm looking into it in another separate PR).

Thanks again!