### PR TITLE
Optionally install system dependencies (depexts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
 Only one input for now.
 
 - `automagic`: if `true`, it will run automatically `dune pkg lock`, `dune build` and `dune runtest`. Defaults to `false`.
+- `install-depexts`: if `true`, it will automatically install system dependencies (depexts) listed by `dune show depexts` using the appropriate package manager (`apt-get` on Linux, `brew` on macOS). Defaults to `false`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Install depexts
       shell: bash
       run: |
-        bash "${{ github.action_path }}/install-depexts.sh"
+        ${{ github.action_path }}/install-depexts.sh
       env:
         RUNNER_OS: ${{ runner.os }}
       if: inputs.install-depexts == 'true'

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,13 @@ description: Install Dune (developer preview)
 author: Samuel Hym
 inputs:
   automagic:
-    description: 'Whether to run automatically all the standard lock, build, test steps'
+    description: "Whether to run automatically all the standard lock, build, test steps"
     required: false
-    default: 'false'
+    default: "false"
+  install-depexts:
+    description: "Whether to automatically install system dependencies (depexts) using `dune show depexts`."
+    required: false
+    default: "false"
 outputs:
   dune-cache-hit:
     description: "A boolean value to indicate the Dune cache was found in the GHA cache"
@@ -31,6 +35,13 @@ runs:
       run: |
         dune pkg lock
       if: inputs.automagic == 'true'
+    - name: Install depexts
+      shell: bash
+      run: |
+        bash "${{ github.action_path }}/install-depexts.sh"
+      env:
+        RUNNER_OS: ${{ runner.os }}
+      if: inputs.install-depexts == 'true'
     - name: Build project
       shell: bash
       run: |

--- a/install-depexts.sh
+++ b/install-depexts.sh
@@ -4,25 +4,39 @@ set -euo pipefail
 # This script installs system dependencies (depexts) listed by `dune show depexts`.
 # It is intended to be called from the setup-dune composite action.
 
+echo "[install-depexts] Starting."
+
 : "${RUNNER_OS:?RUNNER_OS must be set}"
 
-DEPEXT_LIST="$(dune show depexts 2>&1)"
+DEPEXT_TEMPFILE="$(mktemp)"
+if dune show depexts >"$DEPEXT_TEMPFILE" 2>&1; then
+  DEPEXT_LIST="$(cat "$DEPEXT_TEMPFILE")"
+else
+  cat "$DEPEXT_TEMPFILE"
+  echo "[install-depexts] dune show depexts failed"
+  rm -f "$DEPEXT_TEMPFILE"
+  exit 1
+fi
+rm -f "$DEPEXT_TEMPFILE"
+
+echo "[install-depexts] DEPEXT_LIST='$(printf '%s' "$DEPEXT_LIST" | sed ':a;N;$!ba;s/\n/\\n/g')'"
+
 if [ -z "$DEPEXT_LIST" ]; then
-  echo "[setup-dune] No depexts to install."
+  echo "[install-depexts] No depexts to install."
   exit 0
 fi
 
 if [ "${RUNNER_OS}" = "Linux" ]; then
-  echo "[setup-dune] Installing depexts with apt-get:"
+  echo "[install-depexts] Installing depexts with apt-get:"
   echo "$DEPEXT_LIST"
   sudo apt-get update
   xargs -r sudo apt-get install -y <<< "$DEPEXT_LIST"
 elif [ "${RUNNER_OS}" = "macOS" ]; then
-  echo "[setup-dune] Installing depexts with brew:"
+  echo "[install-depexts] Installing depexts with brew:"
   echo "$DEPEXT_LIST"
   brew update
   xargs -r brew install <<< "$DEPEXT_LIST"
 else
-  echo "[setup-dune] Depext installation is not supported on this OS: ${RUNNER_OS}"
+  echo "[install-depexts] Depext installation is not supported on this OS: ${RUNNER_OS}"
   exit 1
 fi

--- a/install-depexts.sh
+++ b/install-depexts.sh
@@ -19,7 +19,7 @@ else
 fi
 rm -f "$DEPEXT_TEMPFILE"
 
-echo "[install-depexts] DEPEXT_LIST='$(printf '%s' "$DEPEXT_LIST" | sed ':a;N;$!ba;s/\n/\\n/g')'"
+echo "[install-depexts] DEPEXT_LIST='$(printf '%s' "$DEPEXT_LIST" | awk '{printf "%s\\n", $0}')'"
 
 if [ -z "$DEPEXT_LIST" ]; then
   echo "::debug::[install-depexts] No depexts to install."

--- a/install-depexts.sh
+++ b/install-depexts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # This script installs system dependencies (depexts) listed by `dune show depexts`.
 # It is intended to be called from the setup-dune composite action.
 
-echo "[install-depexts] Starting."
+echo "::debug::[install-depexts] Starting."
 
 : "${RUNNER_OS:?RUNNER_OS must be set}"
 
@@ -22,18 +22,16 @@ rm -f "$DEPEXT_TEMPFILE"
 echo "[install-depexts] DEPEXT_LIST='$(printf '%s' "$DEPEXT_LIST" | sed ':a;N;$!ba;s/\n/\\n/g')'"
 
 if [ -z "$DEPEXT_LIST" ]; then
-  echo "[install-depexts] No depexts to install."
+  echo "::debug::[install-depexts] No depexts to install."
   exit 0
 fi
 
 if [ "${RUNNER_OS}" = "Linux" ]; then
-  echo "[install-depexts] Installing depexts with apt-get:"
-  echo "$DEPEXT_LIST"
+  echo "::debug::[install-depexts] Installing depexts with apt-get:"
   sudo apt-get update
   xargs -r sudo apt-get install -y <<< "$DEPEXT_LIST"
 elif [ "${RUNNER_OS}" = "macOS" ]; then
-  echo "[install-depexts] Installing depexts with brew:"
-  echo "$DEPEXT_LIST"
+  echo "::debug::[install-depexts] Installing depexts with brew:"
   brew update
   xargs -r brew install <<< "$DEPEXT_LIST"
 else

--- a/install-depexts.sh
+++ b/install-depexts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script installs system dependencies (depexts) listed by `dune show depexts`.
+# It is intended to be called from the setup-dune composite action.
+
+: "${RUNNER_OS:?RUNNER_OS must be set}"
+
+DEPEXT_LIST="$(dune show depexts 2>&1)"
+if [ -z "$DEPEXT_LIST" ]; then
+  echo "[setup-dune] No depexts to install."
+  exit 0
+fi
+
+if [ "${RUNNER_OS}" = "Linux" ]; then
+  echo "[setup-dune] Installing depexts with apt-get:"
+  echo "$DEPEXT_LIST"
+  sudo apt-get update
+  xargs -r sudo apt-get install -y <<< "$DEPEXT_LIST"
+elif [ "${RUNNER_OS}" = "macOS" ]; then
+  echo "[setup-dune] Installing depexts with brew:"
+  echo "$DEPEXT_LIST"
+  brew update
+  xargs -r brew install <<< "$DEPEXT_LIST"
+else
+  echo "[setup-dune] Depext installation is not supported on this OS: ${RUNNER_OS}"
+  exit 1
+fi


### PR DESCRIPTION
I recently came across [this post](https://discuss.ocaml.org/t/portable-external-dependencies-for-dune-package-management/16767/1) on discuss ocaml.

I wonder if we can make use of this in the context of this job. Sounds like it would be useful to share.

It would be best for the implementation to be linted (shellcheck) and tested, so I'm opening this PR for now just to start a discussion. If you like this approach, we could reconsider after #1 and #2 .

Thanks!