### PR TITLE
Install gpatch on macOS by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,13 +22,22 @@ runs:
       shell: bash
       run: |
         set -e
-        GPATCH_GNUBIN="/opt/homebrew/opt/gpatch/libexec/gnubin"
         brew update
         brew install gpatch
-        if [ "${ACTIONS_STEP_DEBUG:-false}" = "true" ]; then
-          echo "Contents of $GPATCH_GNUBIN:"
-          ls -l "$GPATCH_GNUBIN"
+        # Apple Silicon (macos-latest, macos-14)
+        if [ -d "/opt/homebrew/opt/gpatch/libexec/gnubin" ]; then
+          GPATCH_GNUBIN="/opt/homebrew/opt/gpatch/libexec/gnubin"
+        # Intel (macos-13)
+        elif [ -d "/usr/local/opt/gpatch/libexec/gnubin" ]; then
+          GPATCH_GNUBIN="/usr/local/opt/gpatch/libexec/gnubin"
+        else
+          echo "::error::gpatch gnubin directory not found!"
+          exit 1
         fi
+        DIR_CONTENTS="$(ls -l "$GPATCH_GNUBIN")"
+        while IFS= read -r line; do
+          echo "::debug::$line"
+        done <<< "$DIR_CONTENTS"
         echo "$GPATCH_GNUBIN" >> $GITHUB_PATH
         patch --version
     - name: Install and setup dune

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,13 @@ description: Install Dune (developer preview)
 author: Samuel Hym
 inputs:
   automagic:
-    description: 'Whether to run automatically all the standard lock, build, test steps'
+    description: "Whether to run automatically all the standard lock, build, test steps"
     required: false
-    default: 'false'
+    default: "false"
+  install-patch-on-macOS:
+    description: "Whether to brew install gpatch on macOS (required to build some opam packages)"
+    required: false
+    default: "true"
 outputs:
   dune-cache-hit:
     description: "A boolean value to indicate the Dune cache was found in the GHA cache"
@@ -13,6 +17,20 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install gpatch and add to PATH on macOS
+      if: inputs.install-patch-on-macOS == 'true' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -e
+        GPATCH_GNUBIN="/opt/homebrew/opt/gpatch/libexec/gnubin"
+        brew update
+        brew install gpatch
+        if [ "${ACTIONS_STEP_DEBUG:-false}" = "true" ]; then
+          echo "Contents of $GPATCH_GNUBIN:"
+          ls -l "$GPATCH_GNUBIN"
+        fi
+        echo "$GPATCH_GNUBIN" >> $GITHUB_PATH
+        patch --version
     - name: Install and setup dune
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,9 @@ runs:
         set -e
         brew update
         brew install gpatch
-        # Apple Silicon (macos-latest, macos-14)
-        if [ -d "/opt/homebrew/opt/gpatch/libexec/gnubin" ]; then
-          GPATCH_GNUBIN="/opt/homebrew/opt/gpatch/libexec/gnubin"
-        # Intel (macos-13)
-        elif [ -d "/usr/local/opt/gpatch/libexec/gnubin" ]; then
-          GPATCH_GNUBIN="/usr/local/opt/gpatch/libexec/gnubin"
-        else
+        GPATCH_PREFIX="$(brew --prefix gpatch)"
+        GPATCH_GNUBIN="$GPATCH_PREFIX/libexec/gnubin"
+        if [ ! -d "$GPATCH_GNUBIN" ]; then
           echo "::error::gpatch gnubin directory not found!"
           exit 1
         fi


### PR DESCRIPTION
This new step addresses some common build issues on macOS where patch files are not correctly applied.

Certain opam pkg projects may have as dependencies require `patch` to build, such as `bin_prot.v0.17.0-1.pkg`:

```lisp
(build
 (all_platforms
  ((action
    (progn
     (patch remove-outdated-mirage-xen-cross-compilation-rules.patch)
     (run dune build -p %{pkg-self:name} -j %{jobs}))))))
```

Fixes #6 .