### PR TITLE
Use unique cache keys

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,10 @@ runs:
       with:
         path: |
           ${{ env.DUNE_CACHE_ROOT }}
-        key: dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+        key: dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/dune-project',inputs.directory)) }}-${{ github.sha }}
+        restore-keys: |
+          dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/dune-project',inputs.directory)) }}-
+          dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-
     - name: Run the main action script
       shell: bash
       env:


### PR DESCRIPTION
Make sure that the cache is updated on every commit.
Rely on `dune-project` to provide a good hint about the best previous cache to reuse, as it changes with new dependencies.

Unfortunately, this doesn’t solve the issue with the compiler being rebuilt every time (see ocaml/dune#12390) and I didn’t manage to work around it by caching `_build`.

@mbarbin: does this PR solve #3 (as far as possible) for you?