### PR TITLE
Reflect rebrand of "preview" to "nightly"

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ubuntu-latest, macos-latest, macos-13]
-        version: [dev, latest, 3.19.1]
+        version: [nightly, latest, 3.19.1]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
 
 | Key         | Meaning                                                 | Default value           |
 | ----------- | ------------------------------------------------------- | ----------------------- |
-| `version`   | version of dune to use                                  | `dev`                   |
+| `version`   | version of dune to use                                  | `nightly`               |
 | `directory` | where is the project that should be built and tested    | current directory (`.`) |
 | `automagic` | when `true`, triggers `pkg lock`, `build` and `runtest` | `false`                 |
 | `steps`     | fine-grain control over the steps to run                | empty, use `automagic`  |
@@ -38,9 +38,9 @@ jobs:
 
 The `version` can have the following special values:
 
-- `dev` for the latest [nightly release](https://nightly.dune.build/): this is
-  the default at the moment since dune package management is still moving fast
-  and targeted at early adopters.
+- `nightly` for the latest [nightly release](https://nightly.dune.build/): this
+  is the default at the moment since dune package management is still moving
+  fast and targeted at early adopters.
 - `latest` for the latest stable release of dune: for CI systems that want more
   stable use of dune package management.
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: 'Which version of the Dune binary to install'
     required: false
-    default: 'dev'
+    default: 'nightly'
   automagic:
     description: 'Whether to run automatically all the standard lock, build, test steps'
     required: false

--- a/setupdune.sh
+++ b/setupdune.sh
@@ -11,7 +11,7 @@ abort() {
 
 install-dune() {
   case "$SETUPDUNEVERSION" in
-    dev)
+    nightly|dev)
       (set -x; curl -fsSL https://get.dune.build/install | sh)
       ;;
     latest)


### PR DESCRIPTION
A correlate of https://github.com/ocaml-dune/binary-distribution/pull/171 

As we prepare to bring milestone https://github.com/ocaml/dune/milestone/62 to a close, we are clarifying the nature of the so called "preview" by rebranding it as merely a nightly binary of dune.