### PR TITLE
Simplify directory concatenation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,14 +40,7 @@ runs:
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "DUNE_CACHE_ROOT=$HOME/.cache/dune" >> "$GITHUB_ENV"
-        case "$SETUPDUNEDIR" in
-          .|./)
-            echo "BUILDDIR=$PWD/_build" >> "$GITHUB_ENV"
-            ;;
-          *)
-            echo "BUILDDIR=$PWD/$SETUPDUNEDIR/_build" >> "$GITHUB_ENV"
-            ;;
-        esac
+        echo "BUILDDIR=$(realpath -m "$PWD/$SETUPDUNEDIR/_build")" >> "$GITHUB_ENV"
     - name: Cache dune’s cache and build artefacts
       uses: actions/cache@v5
       id: dune-cache


### PR DESCRIPTION
###  Summary

  - Fix warning from actions/cache when directory input uses ./ syntax (e.g., `directory: ./test`)
  - Simplify the script by replacing the case statement with a single `realpath -m` call

###  Motivation

  When using this action with the input directory set to ./test (as opposed to test), the actions/cache post step emits a warning. For example, taken from [here](https://github.com/mbarbin/dunolint-actions/actions/runs/21031304915/job/60467807048) in the `Post Check build build and tests` section:

```text
  Warning: Invalid pattern '/home/runner/work/dunolint-actions/dunolint-actions/./test/_build'. Relative pathing '.' and '..' is not allowed.
```

  There was already a pattern in place to avoid concatenating the default value `.` when the directory input is not set. Using `realpath -m` addresses both points:

  1. Makes the script more systematic by avoiding the if-then-else
  2. Supports local directory passed with the ./ syntax

Note I have actually "fixed" my action to remove the "./" prefix from that input, but I am guessing this is a common "mistake" or style to use, and it's probably best to cover that in the actions directly.