### PR TITLE
Pin actions/cache to full SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
             ;;
         esac
     - name: Cache dune’s cache and build artefacts
-      uses: actions/cache@v5
+      uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
       id: dune-cache
       with:
         path: |


### PR DESCRIPTION
This PR allows users of `setup-dune` to run in a GitHub mode where the settings enforces the use of full-length SHA for actions dependencies.

What I witness in my testing with this repo is that when you enable *Require actions to be pinned to a full-length commit SHA* in your repository's settings (under *Settings → Actions → General*), GitHub enforces this requirement on all actions used in your workflow, including:
  - Actions you call directly
  - Actions called by composite actions you use (like setup-dune) and nested action dependencies

It would seem that the action author's choice of pinning strategy affects all consumers (when an action uses tag references (like @ v5), anyone with strict SHA pinning requirements cannot use that action).

One non intuitive aspect I find with this, is that while I understand how the strict-setting may be desirable from a security standpoint, it is also worth noting that this means that consumers would not get potential security patches from upstream dependencies automatically without updating their actions (and this requires more frequent updates from the setup-dune maintainers too).

I'm not 100% sure what to think yet, opening this for a discussion.