### PR TITLE
Cache readonly

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -79,6 +79,7 @@ jobs:
           workspace: ${{ matrix.workspace }}
           display: ${{ matrix.display }}
           cache-prefix: ${{ matrix.cache-prefix }}
+          cache-readonly: ${{ github.ref != 'refs/heads/main' }}
           traces-as-artifact: ${{ matrix.traces-as-artifact }}
         continue-on-error: ${{ matrix.fault }}
       - name: Show dune version

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
 | `workspace`          | argument for the `--workspace` option (relative to `directory`) | Dune’s default          |
 | `display`            | argument for the `--display` option                             | Dune’s default          |
 | `cache-prefix`       | prefix for the GitHub Action cache keys                         | `v1`                    |
+| `cache-readonly`     | restore cache but do not save it                                | `false`                 |
 | `traces-as-artifact` | when should traces be uploaded as an artifact                   | `on-failure`            |
 
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Prefix of the cache keys'
     required: false
     default: v1
+  cache-readonly:
+    description: 'Restore cache but do not save it (useful for PRs to avoid cache eviction)'
+    required: false
+    default: 'false'
   traces-as-artifact:
     description: 'Whether the Dune traces should be uploaded as artifact (on-failure (default), always, or never)'
     required: false
@@ -33,7 +37,7 @@ inputs:
 outputs:
   dune-cache-hit:
     description: 'A boolean value to indicate the Dune cache was found in the GHA cache'
-    value: ${{ steps.dune-cache.outputs.cache-hit }}
+    value: ${{ steps.dune-cache.outputs.cache-hit || steps.dune-cache-readonly.outputs.cache-hit }}
 runs:
   using: 'composite'
   steps:
@@ -53,8 +57,21 @@ runs:
             ;;
         esac
     - name: Cache dune’s cache and build artefacts
+      if: inputs.cache-readonly != 'true'
       uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
       id: dune-cache
+      with:
+        path: |
+          ${{ env.DUNE_CACHE_ROOT }}
+          ${{ env.BUILDDIR }}
+        key: ${{ inputs.cache-prefix }}-dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/dune-project',inputs.directory)) }}-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-prefix }}-dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/dune-project',inputs.directory)) }}-
+          ${{ inputs.cache-prefix }}-dune-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}-
+    - name: Restore dune’s cache and build artefacts (cache-readonly)
+      if: inputs.cache-readonly == 'true'
+      uses: actions/cache/restore@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+      id: dune-cache-readonly
       with:
         path: |
           ${{ env.DUNE_CACHE_ROOT }}


### PR DESCRIPTION
- Add a new input to use the cache in a read-only fashion.
- Simplify handling of the `README` to support ongoing development
- Enable the `cache-readonly` repo in the CI of this repo when not on the main branch (applicable to PRs).