### PR TITLE
Add option to override which target is getting built

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
 | `display`            | argument for the `--display` option                             | Dune’s default          |
 | `cache-prefix`       | prefix for the GitHub Action cache keys                         | `v1`                    |
 | `traces-as-artifact` | when should traces be uploaded as an artifact                   | `on-failure`            |
+| `build-target`       | which target to build                                           | Dune’s default          |
 
 
 ### Details

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Whether the Dune traces should be uploaded as artifact (on-failure (default), always, or never)'
     required: false
     default: on-failure
+  build-target:
+    description: 'Which target to build in the build step'
+    required: false
+    default: ''
 outputs:
   dune-cache-hit:
     description: 'A boolean value to indicate the Dune cache was found in the GHA cache'
@@ -72,6 +76,7 @@ runs:
         SETUPDUNEWORKSPACE: ${{ inputs.workspace }}
         SETUPDUNEDISPLAY: ${{ inputs.display }}
         SETUPDUNESTEPS: ${{ inputs.steps }}
+        SETUPDUNEBUILDTARGET: ${{ inputs.build-target }}
         OS: ${{ runner.os }}
         ACTIONPATH: ${{ github.action_path }}
       run: |

--- a/setupdune.sh
+++ b/setupdune.sh
@@ -131,7 +131,11 @@ build-deps() {
 }
 
 build() {
-  dune_aux build
+  if [ -z "$SETUPDUNEBUILDTARGET" ]; then
+    dune_aux build
+  else
+    dune_aux build "$SETUPDUNEBUILDTARGET"
+  fi
 }
 
 runtest() {


### PR DESCRIPTION
This can be useful as `dune build` in some circumstances will run unexepected actions and some projects might fail if not specifying a target.

Closes #31.