### PR TITLE
Use a more recent stable version in this CI test

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
-        version: [nightly, latest, 3.19.1]
+        version: [nightly, latest, 3.21.1]
         steps: ['install-dune enable-pkg lazy-update-depexts install-depexts build-deps build runtest']
         workspace: ['']
         display: ['short']

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
-        version: [nightly, latest, 3.21.1]
+        version: [nightly, latest, 3.22.2]
         steps: ['install-dune enable-pkg lazy-update-depexts install-depexts build-deps build runtest']
         workspace: ['']
         display: ['short']

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
-        version: [nightly, latest, 3.22.2]
+        version: [nightly, latest, 3.23.0]
         steps: ['install-dune enable-pkg lazy-update-depexts install-depexts build-deps build runtest']
         workspace: ['']
         display: ['short']


### PR DESCRIPTION
Use a more recent version in the CI test, with compatibility with the `dune trace` command.