### PR TITLE
Show error message when `dune-workspace` disables package management

### DIFF
--- a/setupdune.sh
+++ b/setupdune.sh
@@ -82,12 +82,14 @@ enable-pkg() {
     *)
       CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/dune"
       if test -e "$CONFIG_DIR/config"; then
-        dune_trace pkg enabled \
-          || abort "dune package management is disabled in your configuration"
+        dune_ pkg enabled || abort \
+          "dune package management is disabled in your global configuration"
       else
         mkdir -p "$CONFIG_DIR"
         printf '(lang dune 3.21)\n(pkg enabled)\n' > "$CONFIG_DIR/config"
         (set -x; cat "$CONFIG_DIR/config")
+        dune_ pkg enabled || abort \
+          "dune package management is disabled in your workspace configuration"
       fi
       ;;
   esac

--- a/setupdune.sh
+++ b/setupdune.sh
@@ -11,15 +11,27 @@ abort() {
   exit 2
 }
 
-dune_aux() {
+# A simple wrapper to run Dune in the correct directory with the workspace
+# setting
+dune_() {
+  x=:
+  case "$1" in
+    "-x")
+      shift
+      x="set -x"
+      ;;
+  esac
+  ($x; cd "$SETUPDUNEDIR" >/dev/null && \
+    dune "$@" ${SETUPDUNEWORKSPACE:+--workspace="$SETUPDUNEWORKSPACE"})
+}
+
+# Run Dune recording trace (and displaying it if requested)
+dune_trace() {
   status=0
   trace_file="_build/trace-$*.$SETUPDUNE_TRACEEXT"
   trace_file="${trace_file// /_}"
-  (set -x; cd "$SETUPDUNEDIR" && \
-    dune "$@" \
-      --trace-file="$trace_file" \
-      ${SETUPDUNEWORKSPACE:+--workspace="$SETUPDUNEWORKSPACE"} \
-      ${SETUPDUNEDISPLAY:+--display="$SETUPDUNEDISPLAY"}) \
+  dune_ -x "$@" --trace-file="$trace_file" \
+      ${SETUPDUNEDISPLAY:+--display="$SETUPDUNEDISPLAY"} \
     || status=$?
   if ! test "$status" = 0; then
     echo "::endgroup::"
@@ -65,12 +77,12 @@ enable-pkg() {
   case "$(dune --version)" in
     3.19*|3.20*)
       mkdir -p "$SETUPDUNEDIR/_build"
-      (set -x; cd "$SETUPDUNEDIR" && test -d dune.lock) || dune_aux pkg lock
+      (set -x; cd "$SETUPDUNEDIR" && test -d dune.lock) || dune_trace pkg lock
       ;;
     *)
       CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/dune"
       if test -e "$CONFIG_DIR/config"; then
-        dune_aux pkg enabled \
+        dune_trace pkg enabled \
           || abort "dune package management is disabled in your configuration"
       else
         mkdir -p "$CONFIG_DIR"
@@ -107,9 +119,7 @@ install-gpatch() {
 }
 
 install-depexts() {
-  DEPEXTS="$(cd "$SETUPDUNEDIR" >/dev/null && \
-             dune show depexts \
-               ${SETUPDUNEWORKSPACE:+--workspace="$SETUPDUNEWORKSPACE"} 2>&1)" \
+  DEPEXTS="$(dune_ show depexts 2>&1)" \
     || abort "got \"$DEPEXTS\" when listing depexts"
   case "$OS,$DEPEXTS" in
     *,) # No depexts to install
@@ -128,15 +138,15 @@ install-depexts() {
 }
 
 build-deps() {
-  dune_aux build @pkg-install
+  dune_trace build @pkg-install
 }
 
 build() {
-  dune_aux build
+  dune_trace build
 }
 
 runtest() {
-  dune_aux runtest
+  dune_trace runtest
 }
 
 expand_steps() {

--- a/setupdune.sh
+++ b/setupdune.sh
@@ -32,7 +32,7 @@ dune_aux() {
       (set -x; cd "$SETUPDUNEDIR" && \
         dune trace commands --trace-file="$trace_file")
     fi
-    exit "$status"
+    return "$status"
   fi
 }
 
@@ -157,14 +157,16 @@ expand_steps() {
 }
 
 w() {
+  status=0
   # Wrap a step to control whether it should run
   case "$STEPS" in
     *"$2"*)
       echo "::group::$1"
-      "$2"
+      "$2" || status=$?
       echo "::endgroup::"
       ;;
   esac
+  test "$status" = 0 || exit "$status"
 }
 
 main() {


### PR DESCRIPTION
Currently you can have no global dune config file but your workspace has `(pkg disabled)`. In this case the code currently assumes that writing `(pkg enabled)` is enough to enable package management but when actually trying to build package management is disabled and there is no `ocamlc` so the build will fail.

This PR adds an error message (unfortunately folded by default) in the case where the workspace disables package management, so we don't attempt to build with disabled package management.